### PR TITLE
MARP-1333 Missing setup path for README_DE.md

### DIFF
--- a/cms-editor-product/zip.xml
+++ b/cms-editor-product/zip.xml
@@ -19,6 +19,7 @@
       <outputDirectory>/</outputDirectory>
       <includes>
         <include>README.md</include>
+                <include>README_DE.md</include>
       </includes>
     </fileSet>
   </fileSets>

--- a/cms-editor-product/zip.xml
+++ b/cms-editor-product/zip.xml
@@ -18,8 +18,7 @@
       <directory>target</directory>
       <outputDirectory>/</outputDirectory>
       <includes>
-        <include>README.md</include>
-                <include>README_DE.md</include>
+        <include>README*.md</include>
       </includes>
     </fileSet>
   </fileSets>


### PR DESCRIPTION
Included README_DE.md in pom.xml and zip.xml