### PR TITLE
docs: update README unsupported notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # CMS editor component
+Product is not SUpported anymore
 A CMS (Content Management System) editor is a user-friendly tool that allows translators to efficiently translate website content using a WYSIWYG (What You See Is What You Get) web editor. This tool enables multiple translators to collaborate and work on translations simultaneously. Users can export all translated content into a zip file, simplifying the process of managing and distributing translated CMS files.
 
 Read our [documentation](cms-editor-product/README.md).


### PR DESCRIPTION
Adds `Product is not SUpported anymore` right below the first heading in root README.md.